### PR TITLE
Fix display backlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,13 @@ The following table summarizes GPIO functionality. Note that this **does not** c
 | 35 | ☒ | ☐ | ☐ | ADC1_CH7, RTC_GPIO5 |
 | 36 | ☒ | ☐ | ☐ | ADC1_CH0, RTC_GPIO0 |
 | 39 | ☒ | ☐ | ☐ | ADC1_CH3, RTC_GPIO3 |
+
+## Backlight control
+
+The built-in board support package expects the LCD backlight to be driven on **GPIO27**. If your board variant leaves the display dark after flashing, explicitly enabling the backlight in firmware can help:
+
+```cpp
+bsp::ESP323248S035C<Main>::set_backlight(255);
+```
+
+This call sets the PWM duty cycle to 100%, ensuring the display is illuminated.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,8 @@ void setup() {
     configTime(0, 0, "pool.ntp.org", "time.nist.gov");
 
     target.init();                 // Init LVGL, display, and input
+    // Ensure the LCD backlight is fully enabled
+    bsp::ESP323248S035C<Main>::set_backlight(255);
     lv_obj_clean(lv_scr_act());   // Clear splash screen
     UI::init();                   // Create main interface (now includes config button)
 


### PR DESCRIPTION
## Summary
- enable the LCD backlight after board initialization
- document the backlight pin and helper call in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686968ff6b8c832e8e4a4b7be0ae04d0